### PR TITLE
Add CloudFlare DNS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pull requests with improvements are welcome. For significant changes, create an 
 
 I'm using this tool right now and it works for me but it is not well tested. I would recommend reading the script before following these instructions.
 
-Currently, this only works for clusters hosted on Digital Ocean.
+Currently, this only works for domains hosted on Digital Ocean DNS and CloudFlare DNS.
 
 Since Flynn does not support persistent volumes, every time the process starts it issues a certificate then begins watching to renew the certificate. Due to [Let's Encrypt rate limits](https://letsencrypt.org/docs/rate-limits/), this can only happen 20 times per week.
 
@@ -35,6 +35,9 @@ Only supports digitalocean right now.
 ### DIGITAL_OCEAN_API_KEY
 
 Get one from [https://cloud.digitalocean.com/account/api/tokens](https://cloud.digitalocean.com/account/api/tokens)
+
+### CLOUDFLARE_API_KEY
+Get one from your CloudFlare profile page.
 
 ### DOMAINS
 

--- a/main.sh
+++ b/main.sh
@@ -8,8 +8,8 @@ if [ -z "$CERTBOT_DNS_PLUGIN" ]; then
     exit 1
 fi
 
-if [ -z "$DIGITAL_OCEAN_API_KEY" ]; then
-    echo "DIGITAL_OCEAN_API_KEY must be set"
+if [ -z "$DIGITAL_OCEAN_API_KEY" ] || [ -z "$CLOUDFLARE_API_KEY" ]; then
+    echo "API key must be set"
     exit 1
 fi
 
@@ -46,16 +46,24 @@ L="$FLYNN_CMD" && curl -sSL -A "`uname -sp`" https://dl.flynn.io/cli | zcat >$L 
 echo "Adding cluster $FLYNN_CLUSTER_HOST..."
 "$FLYNN_CMD" cluster add -p "$FLYNN_TLS_PIN" default "$FLYNN_CLUSTER_HOST" "$FLYNN_CONTROLLER_KEY"
 
-if [ "$CERTBOT_DNS_PLUGIN" != "digitalocean" ]; then
-   echo "CERTBOT_DNS_PLUGIN only supports 'digitalocean'";
-   exit 1;
+if [ "$CERTBOT_DNS_PLUGIN" == "digitalocean" ]; then
+    # Create file needed for certbot
+    echo "Writing DO key to disk..."
+    DIGITAL_OCEAN_SECRET_PATH="/app/digitalocean.ini"
+    echo "dns_digitalocean_token = $DIGITAL_OCEAN_API_KEY" > "$DIGITAL_OCEAN_SECRET_PATH"
+    chmod 600 "$DIGITAL_OCEAN_SECRET_PATH"
 fi
 
-# Create file needed for certbot
-echo "Writing Digital Ocean key to disk..."
-DIGITAL_OCEAN_SECRET_PATH="/app/digitalocean.ini"
-echo "dns_digitalocean_token = $DIGITAL_OCEAN_API_KEY" > "$DIGITAL_OCEAN_SECRET_PATH"
-chmod 600 "$DIGITAL_OCEAN_SECRET_PATH"
+if [ "$CERTBOT_DNS_PLUGIN" == "cloudflare" ]; then
+    # Create file needed for certbot
+    echo "Writing CF key to disk..."
+    CLOUDFLARE_SECRET_PATH="/app/cloudflare.ini"
+    echo "dns_cloudflare_api_key = $CLOUDFLARE_API_KEY" > "$CLOUDFLARE_SECRET_PATH"
+    echo "dns_cloudflare_email = $EMAIL" >> "$CLOUDFLARE_SECRET_PATH"
+    chmod 600 "$CLOUDFLARE_SECRET_PATH"
+fi
+
+
 
 # Get domains array
 echo "Collecting domains..."
@@ -85,16 +93,31 @@ echo "certbot certonly \
         --dns-digitalocean-credentials $DIGITAL_OCEAN_SECRET_PATH \
         -d $COMMA_DOMAINS"
 
-certbot certonly \
-  --work-dir "$CERTBOT_WORK_DIR" \
-  --config-dir "$CERTBOT_CONFIG_DIR" \
-  --logs-dir "$CERTBOT_WORK_DIR/logs" \
-  --agree-tos \
-  --no-eff-email \
-  --dns-digitalocean \
-  --email "$EMAIL" \
-  --dns-digitalocean-credentials "$DIGITAL_OCEAN_SECRET_PATH" \
-  -d "$COMMA_DOMAINS"
+if [ "$CERTBOT_DNS_PLUGIN" == "digitalocean" ]; then
+    certbot certonly \
+      --work-dir "$CERTBOT_WORK_DIR" \
+      --config-dir "$CERTBOT_CONFIG_DIR" \
+      --logs-dir "$CERTBOT_WORK_DIR/logs" \
+      --agree-tos \
+      --no-eff-email \
+      --dns-digitalocean \
+      --email "$EMAIL" \
+      --dns-digitalocean-credentials "$DIGITAL_OCEAN_SECRET_PATH" \
+      -d "$COMMA_DOMAINS"
+fi
+
+if [ "$CERTBOT_DNS_PLUGIN" == "cloudflare" ]; then
+    certbot certonly \
+      --work-dir "$CERTBOT_WORK_DIR" \
+      --config-dir "$CERTBOT_CONFIG_DIR" \
+      --logs-dir "$CERTBOT_WORK_DIR/logs" \
+      --agree-tos \
+      --no-eff-email \
+      --dns-cloudflare \
+      --email "$EMAIL" \
+      --dns-cloudflare-credentials "$CLOUDFLARE_SECRET_PATH" \
+      -d "$COMMA_DOMAINS"
+fi
 
 echo "Updating Flynn routes..."
 # First domain is used as directory path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 certbot==0.26.1
 certbot-dns-digitalocean==0.26.1
+certbot-dns-cloudflare==0.26.1


### PR DESCRIPTION
I added support for the CloudFlare DNS API.

It was relatively straightforward, and I tested it on my cluster - works beautifully.
